### PR TITLE
Updated mozjpg and pngquant image optimization

### DIFF
--- a/src/webpack/config/createConfig.js
+++ b/src/webpack/config/createConfig.js
@@ -162,10 +162,10 @@ module.exports = function createConfig({
                 },
                 mozjpeg: {
                   progressive: true,
-                  quality: 65,
+                  quality: 100,
                 },
                 pngquant: {
-                  quality: '65-90',
+                  quality: '95-100',
                   speed: 4,
                 },
                 gifsicle: {


### PR DESCRIPTION
Issue #22: mozjpeg 65 and pngquant '65-90' don't allow us enough control when building on critical-size projects as they add extra compression. Currently keeping the mozjpeg configuration in the config, to be discussed lately in order to find a good compromise