### PR TITLE
Feature screenshot

### DIFF
--- a/src/webpack/devServer.js
+++ b/src/webpack/devServer.js
@@ -118,7 +118,8 @@ ${chalk.grey.bold('-------------------------------------------------------')}
     const data = {
       config: {},
       url: `http://localhost:${port}/${name}/`,
-      location,
+			location,
+			selector: '.banner',
     };
 
     if (

--- a/src/webpack/devServer.js
+++ b/src/webpack/devServer.js
@@ -122,22 +122,6 @@ ${chalk.grey.bold('-------------------------------------------------------')}
 			selector: '.banner',
     };
 
-    if (
-      result &&
-      result.data &&
-      result.data.settings &&
-      result.data.settings.size &&
-      result.data.settings.size.width &&
-      result.data.settings.size.height
-    ) {
-      data.clip = {
-        x: 0,
-        y: 0,
-        width: result.data.settings.size.width,
-        height: result.data.settings.size.height,
-      };
-    }
-
     screenshot
       .fromUrl(data)
       .then(() => readFile(location))


### PR DESCRIPTION
Miento fixed most of the issues around screenshot feature in richmedia-temple-server 5.0.2 and with a hotfix on richmedia-temple-screenshot.
I added a selector for puppeter to know the banner width/height, this should also work with Expandable banners since we are getting the width and height dynamically.
